### PR TITLE
Return an error instead of panicking when Marshal gets a nil ISA header

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -17,13 +17,24 @@ func (m *Marshaler) Marshal(x *X12Document) ([]byte, error) {
 	if x == nil {
 		return nil, fmt.Errorf("%w: x nil", ErrInvalidArgument)
 	}
+	if x.Interchange == nil {
+		return nil, fmt.Errorf("%w: missing interchange", ErrInvalidFormat)
+	}
 	builder := strings.Builder{}
 	if !x.EnvelopeAutomaticallyAdded {
+		if x.Interchange.Header == nil {
+			return nil, fmt.Errorf("%w: ISA segment missing", ErrInvalidFormat)
+		}
+		if x.Interchange.Trailer == nil {
+			return nil, fmt.Errorf("%w: IEA segment missing", ErrInvalidFormat)
+		}
 		m.encodeISA(x.Interchange.Header, &builder)
 		m.encodeFunctionGroups(x.Interchange.FunctionGroups, &builder)
 		m.encodeIEA(x.Interchange.Trailer, &builder)
 	} else {
-		// TODO: check that there is exactly one function group and one transaction
+		if len(x.Interchange.FunctionGroups) == 0 || len(x.Interchange.FunctionGroups[0].Transactions) == 0 {
+			return nil, fmt.Errorf("%w: auto-enveloped document missing function group or transaction", ErrInvalidFormat)
+		}
 		fg := x.Interchange.FunctionGroups[0]
 		transaction := fg.Transactions[0]
 		m.encodeST(transaction.Header, &builder)

--- a/x12_test.go
+++ b/x12_test.go
@@ -256,3 +256,23 @@ func TestRoundtripping(t *testing.T) {
 func normalizeLineEndings(input string) string {
 	return strings.ReplaceAll(input, "\r\n", "\n")
 }
+
+func TestMarshalNilInterchangeDoesNotPanic(t *testing.T) {
+	// Regression: a document decoded from input lacking an ISA envelope (e.g.
+	// beginning with GS) leaves Interchange.Header nil; Marshal must return an
+	// error instead of panicking. See github.com/tmc/x12/issues/9.
+	in := "GS*HC*SENDER*RECEIVER*20260101*1200*1*X*005010~ST*837*0001~SE*1*0001~GE*1*1~"
+	doc, err := x12.Decode(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+
+	if _, err := (&x12.Marshaler{}).Marshal(doc); err == nil {
+		t.Fatal("Marshal() of a document with a nil ISA header: got nil error, want error")
+	}
+
+	// A nil document and a document with a nil Interchange must also be safe.
+	if _, err := (&x12.Marshaler{}).Marshal(&x12.X12Document{}); err == nil {
+		t.Fatal("Marshal() of a document with a nil Interchange: got nil error, want error")
+	}
+}


### PR DESCRIPTION
`Marshal` now guards the nil `Interchange`, `Header`, and `Trailer` cases (and the empty function-group/transaction case on the auto-envelope path) and returns `ErrInvalidFormat` instead of dereferencing nil. Scoped to stopping the panic — decode behavior is unchanged.

Potentially fixes https://github.com/tmc/x12/issues/9