### PR TITLE
Add lookup functions for human-readable ISA element code descriptions

### DIFF
--- a/isa.go
+++ b/isa.go
@@ -38,3 +38,20 @@ var codeToHumanMap = map[string]string{
 	"ISA08_33": interchangeIDCodeToDefinition["33"],
 	"ISA08_ZZ": interchangeIDCodeToDefinition["ZZ"],
 }
+
+// ISAElementDescription returns the human-readable description of a coded ISA
+// element value. elementID is the ISA element identifier (for example "ISA06")
+// and code is the value found in that element (for example "ZZ"). The boolean
+// is false when no description is known for the given element and code.
+func ISAElementDescription(elementID, code string) (string, bool) {
+	desc, ok := codeToHumanMap[elementID+"_"+code]
+	return desc, ok
+}
+
+// InterchangeIDQualifierDescription returns the human-readable definition of an
+// ISA05/ISA07 interchange ID qualifier code (for example "ZZ" -> "Mutually
+// Defined"). The boolean is false when the code is unknown.
+func InterchangeIDQualifierDescription(code string) (string, bool) {
+	desc, ok := interchangeIDCodeToDefinition[code]
+	return desc, ok
+}

--- a/isa_test.go
+++ b/isa_test.go
@@ -1,0 +1,28 @@
+package x12_test
+
+import (
+	"testing"
+
+	"github.com/tmc/x12"
+)
+
+func TestISAElementDescription(t *testing.T) {
+	if got, ok := x12.ISAElementDescription("ISA06", "ZZ"); !ok || got != "Mutually Defined" {
+		t.Errorf("ISAElementDescription(ISA06, ZZ) = %q, %v; want \"Mutually Defined\", true", got, ok)
+	}
+	if got, ok := x12.ISAElementDescription("ISA01", "00"); !ok || got == "" {
+		t.Errorf("ISAElementDescription(ISA01, 00) = %q, %v; want non-empty, true", got, ok)
+	}
+	if _, ok := x12.ISAElementDescription("ISA06", "NOPE"); ok {
+		t.Error("ISAElementDescription(ISA06, NOPE) = ok=true; want false")
+	}
+}
+
+func TestInterchangeIDQualifierDescription(t *testing.T) {
+	if got, ok := x12.InterchangeIDQualifierDescription("30"); !ok || got != "U.S. Federal Tax Identification Number" {
+		t.Errorf("InterchangeIDQualifierDescription(30) = %q, %v", got, ok)
+	}
+	if _, ok := x12.InterchangeIDQualifierDescription("zz-unknown"); ok {
+		t.Error("InterchangeIDQualifierDescription(unknown) = ok=true; want false")
+	}
+}


### PR DESCRIPTION
Exposes two lookup functions that resolve coded ISA element values to human-readable text, wiring up the previously unused code-description maps.

## How to use

```go
// Describe a coded ISA element value by element id + code:
desc, ok := x12.ISAElementDescription("ISA06", "ZZ")
// desc == "Mutually Defined", ok == true

// Describe an interchange ID qualifier code (ISA05/ISA07):
desc, ok = x12.InterchangeIDQualifierDescription("30")
// desc == "U.S. Federal Tax Identification Number", ok == true
```

`ok` is false when the element/code (or qualifier code) is unknown. Typical use is to render a decoded ISA header for humans, e.g. look up `header.InterchangeSenderIDQualifier` via `ISAElementDescription("ISA06", code)`.
