### PR TITLE
Reject a GS segment that appears before any ISA segment

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -218,6 +218,9 @@ func (s *decodeState) parseIEA(elements []string) error {
 }
 
 func (s *decodeState) parseGS(elements []string) error {
+	if s.doc.Interchange.Header == nil {
+		return s.Errorf("%w: GS segment without ISA segment", ErrInvalidFormat)
+	}
 	if len(elements) < 9 {
 		return s.Errorf("GS: %w", ErrMissingElement)
 	}

--- a/decode_gs_without_isa_test.go
+++ b/decode_gs_without_isa_test.go
@@ -1,0 +1,19 @@
+package x12_test
+
+import (
+	"errors"
+	"github.com/tmc/x12"
+	"strings"
+	"testing"
+)
+
+func TestDecodeGSWithoutISA(t *testing.T) {
+	in := "GS*HC*S*R*20200101*1200*1*X*004010~ST*837*0001~SE*1*0001~GE*1*1~"
+	_, err := x12.Decode(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("Decode of GS-without-ISA: got nil error, want error")
+	}
+	if !errors.Is(err, x12.ErrInvalidFormat) {
+		t.Errorf("got %v, want ErrInvalidFormat", err)
+	}
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -104,14 +104,14 @@ func Test_decodeState_parseGS(t *testing.T) {
 	}{
 		{
 			name:     "too few elements",
-			state:    decodeState{doc: &X12Document{Interchange: &Interchange{FunctionGroups: []*FunctionGroup{}}}, currentFunctionGroup: &FunctionGroup{}},
+			state:    decodeState{doc: &X12Document{Interchange: &Interchange{Header: &ISA{}, FunctionGroups: []*FunctionGroup{}}}, currentFunctionGroup: &FunctionGroup{}},
 			elements: []string{"GS", "AG", "5137624388", "123456789", "20041216", "0805", "95071", "X"},
 			want:     nil,
 			wantErr:  true,
 		},
 		{
 			name:     "typical segment",
-			state:    decodeState{doc: &X12Document{Interchange: &Interchange{FunctionGroups: []*FunctionGroup{}}}, currentFunctionGroup: &FunctionGroup{}},
+			state:    decodeState{doc: &X12Document{Interchange: &Interchange{Header: &ISA{}, FunctionGroups: []*FunctionGroup{}}}, currentFunctionGroup: &FunctionGroup{}},
 			elements: []string{"GS", "AG", "5137624388", "123456789", "20041216", "0805", "95071", "X", "005010"},
 			want: &GS{
 				FunctionalIDCode:         "AG",
@@ -127,7 +127,7 @@ func Test_decodeState_parseGS(t *testing.T) {
 		},
 		{
 			name:     "too many elements",
-			state:    decodeState{doc: &X12Document{Interchange: &Interchange{FunctionGroups: []*FunctionGroup{}}}, currentFunctionGroup: &FunctionGroup{}},
+			state:    decodeState{doc: &X12Document{Interchange: &Interchange{Header: &ISA{}, FunctionGroups: []*FunctionGroup{}}}, currentFunctionGroup: &FunctionGroup{}},
 			elements: []string{"GS", "AG", "5137624388", "123456789", "20041216", "0805", "95071", "X", "005010", "Hello", "World!"},
 			want: &GS{
 				FunctionalIDCode:         "AG",


### PR DESCRIPTION
Makes `parseGS` reject a `GS` segment that appears before any `ISA`, matching the existing guards against `GE`-without-`GS` and `ST`-without-`GS`.

## How to use

No API change. Behavioral change on `Decode`: a document beginning with `GS` (no `ISA` envelope) now returns an error instead of silently producing a document with a nil interchange header.

```go
_, err := x12.Decode(r)
if errors.Is(err, x12.ErrInvalidFormat) {
    // input was missing its ISA envelope
}
```

Note: this tightens the decoder — inputs that previously parsed leniently (nil header, deferred failure) now fail fast at decode time.
