### PR TITLE
Reject a document containing more than one ISA segment

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -182,6 +182,9 @@ func (s *decodeState) getSegmentParsers() map[string]segmentParser {
 }
 
 func (s *decodeState) parseISA(elements []string) error {
+	if s.doc.Interchange.Header != nil {
+		return s.Errorf("%w: duplicate ISA segment", ErrInvalidFormat)
+	}
 	if len(elements) < 17 {
 		return s.Errorf("ISA: %w", ErrMissingElement)
 	}

--- a/decode_duplicate_isa_test.go
+++ b/decode_duplicate_isa_test.go
@@ -1,0 +1,20 @@
+package x12_test
+
+import (
+	"errors"
+	"github.com/tmc/x12"
+	"strings"
+	"testing"
+)
+
+func TestDecodeDuplicateISA(t *testing.T) {
+	isa2 := "ISA*00*          *00*          *ZZ*SECOND         *ZZ*RECEIVER       *200101*1200*U*00401*000000002*0*P*:~"
+	in := "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *200101*1200*U*00401*000000001*0*P*:~" + isa2 + "IEA*1*000000002~"
+	_, err := x12.Decode(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("Decode of document with two ISA segments: got nil error, want error")
+	}
+	if !errors.Is(err, x12.ErrInvalidFormat) {
+		t.Errorf("got %v, want ErrInvalidFormat", err)
+	}
+}


### PR DESCRIPTION
Makes `parseISA` reject a document that contains more than one `ISA` segment instead of silently overwriting the first header.

## How to use

No API change. Behavioral change on `Decode`:

```go
_, err := x12.Decode(r)
if errors.Is(err, x12.ErrInvalidFormat) {
    // input contained a duplicate ISA segment
}
```

Previously a second `ISA` replaced the first envelope with no error; valid single-ISA documents are unaffected.
