### PR TITLE
Clear the current transaction after parsing an SE trailer

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -283,6 +283,9 @@ func (s *decodeState) parseSE(elements []string) error {
 		NumberOfIncludedSegments:    elements[1],
 		TransactionSetControlNumber: elements[2],
 	}
+	// The transaction is now closed; clear it so a segment appearing before the
+	// next ST is rejected instead of being appended to this transaction.
+	s.currentTransaction = nil
 	return nil
 }
 

--- a/decode_segment_after_se_test.go
+++ b/decode_segment_after_se_test.go
@@ -1,0 +1,19 @@
+package x12_test
+
+import (
+	"errors"
+	"github.com/tmc/x12"
+	"strings"
+	"testing"
+)
+
+func TestDecodeSegmentAfterSE(t *testing.T) {
+	in := "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *200101*1200*U*00401*000000001*0*P*:~GS*HC*S*R*20200101*1200*1*X*004010~ST*837*0001~NM1*IL*1~SE*2*0001~ZZ*orphan~GE*1*1~IEA*1*000000001~"
+	_, err := x12.Decode(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("Decode with a segment between SE and the next ST: got nil error, want error")
+	}
+	if !errors.Is(err, x12.ErrInvalidFormat) {
+		t.Errorf("got %v, want ErrInvalidFormat", err)
+	}
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -320,11 +320,14 @@ func Test_decodeState_parseSE(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// parseSE clears currentTransaction once the transaction is closed,
+			// so capture it beforehand to inspect the trailer it set.
+			transaction := tt.state.currentTransaction
 			if err := tt.state.parseSE(tt.elements); (err != nil) != tt.wantErr {
 				t.Errorf("parseSE() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr {
-				got := tt.state.currentTransaction.Trailer
+				got := transaction.Trailer
 				if !reflect.DeepEqual(got, tt.want) {
 					t.Errorf("parseSE() got = %v, want %v", got, tt.want)
 				}


### PR DESCRIPTION
Makes `parseSE` clear the current transaction once it is closed, so a segment appearing between `SE` and the next `ST` is rejected as a segment without an `ST` instead of being silently appended to the closed transaction.

## How to use

No API change. Behavioral change on `Decode`:

```go
_, err := x12.Decode(r)
if errors.Is(err, x12.ErrInvalidFormat) {
    // a segment appeared after SE but before the next ST
}
```

Well-formed documents (segments only between `ST` and `SE`) are unaffected.
