### PR TITLE
x12: Allow decoding segments larger than bufio's 64KB default

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -32,7 +32,13 @@ type decodeState struct {
 	currentTransaction   *Transaction
 
 	withRelaxedSegmentIDWhitespace bool
+	maxSegmentSize                 int
 }
+
+// defaultMaxSegmentSize is the largest single segment, in bytes, that Decode
+// accepts by default. It is far above bufio.MaxScanTokenSize (64 KB) so that
+// large free-text or binary segments decode without configuration.
+const defaultMaxSegmentSize = 16 * 1024 * 1024
 
 // DecodeOption is a function that can be used to configure the decoder.
 type DecodeOption func(*decodeState)
@@ -44,12 +50,24 @@ func WithRelaxedSegmentIDWhitespace() DecodeOption {
 	}
 }
 
+// WithMaxSegmentSize sets the largest single segment, in bytes, that the
+// decoder accepts. It overrides the default of 16 MiB. A non-positive value is
+// ignored.
+func WithMaxSegmentSize(n int) DecodeOption {
+	return func(state *decodeState) {
+		if n > 0 {
+			state.maxSegmentSize = n
+		}
+	}
+}
+
 // Decode decodes an X12 document from an io.Reader
 func Decode(in io.Reader, opts ...DecodeOption) (*X12Document, error) {
 	state := initializeDecodeState(opts)
 	segmentParsers := state.getSegmentParsers()
 
 	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), state.maxSegmentSize)
 	scanner.Split(scanEDI)
 	for scanner.Scan() {
 		if err := state.processLine(scanner.Text(), segmentParsers); err != nil {
@@ -71,6 +89,7 @@ func initializeDecodeState(opts []DecodeOption) *decodeState {
 		lineIndex:            0,
 		currentFunctionGroup: nil,
 		currentTransaction:   nil,
+		maxSegmentSize:       defaultMaxSegmentSize,
 	}
 	for _, opt := range opts {
 		opt(state)

--- a/decode_large_segment_test.go
+++ b/decode_large_segment_test.go
@@ -1,0 +1,20 @@
+package x12_test
+
+import (
+	"github.com/tmc/x12"
+	"strings"
+	"testing"
+)
+
+func TestDecodeLargeSegment(t *testing.T) {
+	big := strings.Repeat("A", 70000) // > bufio's 64KB default
+	in := "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *200101*1200*U*00401*000000001*0*P*:~GS*HC*S*R*20200101*1200*1*X*004010~ST*837*0001~NTE**" + big + "~SE*3*0001~GE*1*1~IEA*1*000000001~"
+	doc, err := x12.Decode(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Decode of 70KB segment: %v", err)
+	}
+	seg := doc.Interchange.FunctionGroups[0].Transactions[0].Segments[0]
+	if got := len(seg.Elements[1].Value); got != 70000 {
+		t.Errorf("NTE value length = %d, want 70000", got)
+	}
+}


### PR DESCRIPTION
Enlarges the `bufio.Scanner` buffer so segments larger than the 64 KB default decode, and adds a `WithMaxSegmentSize` option to tune the cap.

## How to use

```go
// Default: segments up to 16 MiB decode with no configuration.
doc, err := x12.Decode(r)

// Raise (or lower) the per-segment limit, e.g. 64 MiB:
doc, err = x12.Decode(r, x12.WithMaxSegmentSize(64*1024*1024))
```

A non-positive value passed to `WithMaxSegmentSize` is ignored. Previously any single segment over 64 KB failed with "bufio.Scanner: token too long".
